### PR TITLE
Setting value to null when empty = remove from table

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -84,8 +84,29 @@ class PlgSystemFields extends JPlugin
 		// Loop over the fields
 		foreach ($fields as $field)
 		{
-			// Determine the value if it is available from the data
-			$value = key_exists($field->name, $data['com_fields']) ? $data['com_fields'][$field->name] : $field->rawvalue;
+			// Determine the value if it is (un)available from the data
+			if (key_exists($field->name, $data['com_fields']))
+			{
+				if ($data['com_fields'][$field->name] === false)
+				{
+					$value = null;
+				}
+				else
+				{
+					$value = $data['com_fields'][$field->name];
+				}
+			}
+			// Field not available on form, use stored value
+			else
+			{
+				$value = $field->rawvalue;
+			}
+
+			// If no value set (empty) remove value fom database
+			if (empty($value))
+			{
+				$value = null;
+			}
 
 			// JSON encode value for complex fields
 			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))


### PR DESCRIPTION
without this change an empty field would be:
on first save article with value empty created in table;
on second save of article deleted from table;
on third save created with value empty in table;
on fourth save of article deleted from table,
etc. etc.
This change removes an empty value from the #__fields_value table (keeping the table only filled with actual values)

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

