### PR TITLE
Fix to removing article text when saving article

### DIFF
--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -937,12 +937,6 @@ class FormController extends BaseController
 		// Loop over all fields
 		foreach ($form->getFieldset() as $field)
 		{
-			// Make sure the data array has an entry when there is no group
-			if (!$field->group && !key_exists($field->fieldname, $data))
-			{
-				$data[$field->fieldname] = false;
-			}
-
 			// If the field has no group, we are done here
 			if (!$field->group)
 			{


### PR DESCRIPTION
As I do not 'understand' why the removed lines where present this is a 'blindshot' at fixing this.
It is also possible to even further tune this to com_fields (because that is the reason why this method was added here?) by setting
```
if (!field->group == 'com_fields') ... continue
```
but that would introduce component specific code which I understand is a nogo :)

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

