### PR TITLE
allowing value 0 to be saved

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -129,7 +129,7 @@ class PlgSystemFields extends JPlugin
 			}
 
 			// If no value set (empty) remove value from database
-			if (empty($value))
+			if (is_array($value) ? !count($value) : !strlen($value))
 			{
 				$value = null;
 			}


### PR DESCRIPTION
when setting a value of 0 in a text field the function empty will return true > setting the value to null

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

