### PR TITLE
Fix jquery::framework to use WebAsset, and add "defer=false" attribute

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -258,7 +258,12 @@
         "provideAssets": [
           {
             "name": null,
-            "js": ["jquery.min.js"]
+            "js": ["jquery.min.js"],
+            "attribute": {
+              "jquery.min.js": {
+                "defer": false
+              }
+            }
           }
         ],
         "dependencies": [],
@@ -274,7 +279,12 @@
           {
             "name": null,
             "js": ["jquery-migrate.min.js"],
-            "dependencies": ["jquery"]
+            "dependencies": ["jquery"],
+            "attribute": {
+              "jquery-migrate.min.js": {
+                "defer": false
+              }
+            }
           }
         ],
         "dependencies": [
@@ -398,7 +408,12 @@
         "provideAssets": [
           {
             "name": null,
-            "js": ["css-vars-ponyfill.min.js"]
+            "js": ["css-vars-ponyfill.min.js"],
+            "attribute": {
+              "css-vars-ponyfill.min.js": {
+                "defer": false
+              }
+            }
           }
         ]
       },

--- a/build/media/legacy/joomla.asset.json
+++ b/build/media/legacy/joomla.asset.json
@@ -11,7 +11,12 @@
       ],
       "js": [
         "media/legacy/js/jquery-noconflict.min.js"
-      ]
+      ],
+      "attribute": {
+        "media/legacy/js/jquery-noconflict.min.js": {
+          "defer": false
+        }
+      }
     }
   }
 }

--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -40,7 +40,7 @@ abstract class JHtmlJquery
 	 *
 	 * @since   3.0
 	 *
-	 * @deprecated 5.0  Use Factory::getDocument()->getWebAssetManager()->enableAsset('jquery')
+	 * @deprecated 5.0  Use $app->getDocument()->getWebAssetManager()->enableAsset('jquery')
 	 */
 	public static function framework($noConflict = true, $debug = null, $migrate = false)
 	{
@@ -50,7 +50,7 @@ abstract class JHtmlJquery
 			return;
 		}
 
-		$wa = Factory::getDocument()->getWebAssetManager();
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 		$wa->enableAsset('jquery');
 
 		// Check if we are loading in noConflict

--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -39,6 +39,8 @@ abstract class JHtmlJquery
 	 * @return  void
 	 *
 	 * @since   3.0
+	 *
+	 * @deprecated 5.0  Use Factory::getDocument()->getWebAssetManager()->enableAsset('jquery')
 	 */
 	public static function framework($noConflict = true, $debug = null, $migrate = false)
 	{
@@ -48,24 +50,19 @@ abstract class JHtmlJquery
 			return;
 		}
 
-		// If no debugging value is set, use the configuration setting
-		if ($debug === null)
-		{
-			$debug = (boolean) Factory::getApplication()->get('debug');
-		}
-
-		HTMLHelper::_('script', 'vendor/jquery/jquery.min.js', array('version' => 'auto', 'relative' => true, 'detectDebug' => $debug), ['defer' => false]);
+		$wa = Factory::getDocument()->getWebAssetManager();
+		$wa->enableAsset('jquery');
 
 		// Check if we are loading in noConflict
 		if ($noConflict)
 		{
-			HTMLHelper::_('script', 'legacy/jquery-noconflict.min.js', array('version' => 'auto', 'relative' => true), ['defer' => false]);
+			$wa->enableAsset('jquery-noconflict');
 		}
 
 		// Check if we are loading Migrate
 		if ($migrate)
 		{
-			HTMLHelper::_('script', 'vendor/jquery-migrate/jquery-migrate.min.js', array('version' => 'auto', 'relative' => true, 'detectDebug' => $debug), ['defer' => false]);
+			$wa->enableAsset('jquery-migrate');
 		}
 
 		static::$loaded[__METHOD__] = true;


### PR DESCRIPTION
This is fix/update for https://github.com/joomla/joomla-cms/pull/22460

Because `jquery::freamwork` not always in use after WebAsset was introduced.


