### PR TITLE
[CMS PR 40147] Use script.php to uninstall the plugin

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -230,6 +230,7 @@ class JoomlaInstallerScript
              * 'pre_function' => Name of an optional migration function to be called before
              *                   uninstalling, `null` if not used.
              */
+             ['type' => 'plugin', 'element' => 'demotasks', 'folder' => 'task', 'client_id' => 0, 'pre_function' => null],
         ];
 
         $db = Factory::getDbo();

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -287,7 +287,7 @@ class JoomlaInstallerScript
     /**
      * This method deletes demo tasks of the obsolete demo task plugin.
      *
-     * @param   \stdClass  $data  Object with `extension_id`, `enabled` and `params` of the extension
+     * @param   \stdClass  $data  Row from the extensions table
      *
      * @return  void
      *

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -230,7 +230,7 @@ class JoomlaInstallerScript
              * 'pre_function' => Name of an optional migration function to be called before
              *                   uninstalling, `null` if not used.
              */
-             ['type' => 'plugin', 'element' => 'demotasks', 'folder' => 'task', 'client_id' => 0, 'pre_function' => null],
+             ['type' => 'plugin', 'element' => 'demotasks', 'folder' => 'task', 'client_id' => 0, 'pre_function' => 'deleteDemoTasks'],
         ];
 
         $db = Factory::getDbo();
@@ -281,6 +281,31 @@ class JoomlaInstallerScript
                 echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
                 throw $e;
             }
+        }
+    }
+
+    /**
+     * This method deletes demo tasks of the obsolete demo task plugin.
+     *
+     * @param   \stdClass  $data  Object with `extension_id`, `enabled` and `params` of the extension
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function deleteDemoTasks($data)
+    {
+        $db = Factory::getDbo();
+
+        try {
+            $db->setQuery(
+                $db->getQuery(true)
+                    ->delete($db->quoteName('#__scheduler_tasks'))
+                    ->where($db->quoteName('type') . ' = ' . $db->quote('demoTask_r1.sleep'))
+            )->execute();
+        } catch (\Exception $e) {
+            echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
+            throw $e;
         }
     }
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -230,7 +230,7 @@ class JoomlaInstallerScript
              * 'pre_function' => Name of an optional migration function to be called before
              *                   uninstalling, `null` if not used.
              */
-             ['type' => 'plugin', 'element' => 'demotasks', 'folder' => 'task', 'client_id' => 0, 'pre_function' => 'deleteDemoTasks'],
+             ['type' => 'plugin', 'element' => 'demotasks', 'folder' => 'task', 'client_id' => 0, 'pre_function' => null],
         ];
 
         $db = Factory::getDbo();
@@ -281,31 +281,6 @@ class JoomlaInstallerScript
                 echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
                 throw $e;
             }
-        }
-    }
-
-    /**
-     * This method deletes demo tasks of the obsolete demo task plugin.
-     *
-     * @param   \stdClass  $data  Row from the extensions table
-     *
-     * @return  void
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    private function deleteDemoTasks($data)
-    {
-        $db = Factory::getDbo();
-
-        try {
-            $db->setQuery(
-                $db->getQuery(true)
-                    ->delete($db->quoteName('#__scheduler_tasks'))
-                    ->where($db->quoteName('type') . ' = ' . $db->quote('demoTask_r1.sleep'))
-            )->execute();
-        } catch (\Exception $e) {
-            echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
-            throw $e;
         }
     }
 

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
@@ -1,1 +1,0 @@
-DELETE FROM `#__scheduler_tasks` WHERE `type` = 'demoTask_r1.sleep';

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
@@ -1,0 +1,1 @@
+DELETE FROM `#__scheduler_tasks` WHERE `type` = 'demoTask_r1.sleep';

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-03-17.sql
@@ -1,2 +1,1 @@
 DELETE FROM `#__scheduler_tasks` WHERE `type` = 'demoTask_r1.sleep';
-DELETE FROM `#__extensions` WHERE `type` = 'plugin' AND `element` = 'demotasks' AND `folder` = 'task' AND `client_id` = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
@@ -1,0 +1,1 @@
+DELETE FROM "#__scheduler_tasks" WHERE "type" = 'demoTask_r1.sleep';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
@@ -1,1 +1,0 @@
-DELETE FROM "#__scheduler_tasks" WHERE "type" = 'demoTask_r1.sleep';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-03-17.sql
@@ -1,2 +1,1 @@
 DELETE FROM "#__scheduler_tasks" WHERE "type" = 'demoTask_r1.sleep';
-DELETE FROM "#__extensions" WHERE "type" = 'plugin' AND "element" = 'demotasks' AND "folder" = 'task' AND "client_id" = 0;


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/40147 .

### Summary of Changes

Use the new function introduced with https://github.com/joomla/joomla-cms/pull/40768 instead of the update SQL script for uninstalling the obsolete plugin and removing its tasks on update.

The update SQL script is still used for removing the task(s).

### Testing Instructions

Code review, or update a 4.4-dev nightly build or 5.0.0-alpha1 to a 5.0-dev update package which contains the changes from here and from the CMS PR.
